### PR TITLE
add leaking via XSLT stylesheet

### DIFF
--- a/leak.html
+++ b/leak.html
@@ -263,6 +263,11 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
 </svg>
 
 <!--
+%XSLT Stylesheets
+-->
+<?xml-stylesheet type="text/xsl" href="https://leaking.via/xslt-stylesheet" ?>
+
+<!--
 %Data Islands
 -->
 <xml src="https://leaking.via/xml-src" id="xml"></xml>


### PR DESCRIPTION
XSLT stylesheets can be referenced in browsers via an XML processing instruction. See, e.g., [MSDN](https://msdn.microsoft.com/en-us/library/ms757857%28v=vs.85%29.aspx).
