### PR TITLE
Let CSS mask leak in Chrome

### DIFF
--- a/leak.html
+++ b/leak.html
@@ -310,6 +310,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
         circle {
             fill: url(https://leaking.via/svg-css-fill#foo);
             mask: url(https://leaking.via/svg-css-mask#foo);
+            -webkit-mask: url(https://leaking.via/svg-css--webkit-mask#foo);
             filter: url(https://leaking.via/svg-css-filter#foo);
             clip-path: url(https://leaking.via/svg-css-clip-path#foo);
         }
@@ -362,6 +363,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
 <circle style="
         fill: url(https://leaking.via/svg-inline-css-fill#foo);
         mask: url(https://leaking.via/svg-inline-css-mask#foo);
+        -webkit-mask: url(https://leaking.via/svg-inline-css--webkit-mask#foo);
         filter: url(https://leaking.via/svg-inline-css-filter#foo);
         clip-path: url(https://leaking.via/svg-inline-css-clip-path#foo);
 "></circle>


### PR DESCRIPTION
Chrome supports CSS mask but with -webkit- prefix
https://developer.mozilla.org/ja/docs/Web/CSS/mask#Browser_compatibility