### PR TITLE
Added another XML data Islands leak

### DIFF
--- a/leak.html
+++ b/leak.html
@@ -16,13 +16,13 @@
 <!--
 %Redirects
 -->
-<meta http-equiv="refresh" content="10; url=http://leaking.via/meta-refresh">
+<meta http-equiv="refresh" content="10; url=https://leaking.via/meta-refresh">
 
 <!--  
 %CSP
 -->
-<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri http://leaking.via/meta-csp-report-uri">
-<meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'self'; report-uri http://leaking.via/meta-csp-report-uri-2">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri https://leaking.via/meta-csp-report-uri">
+<meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'self'; report-uri https://leaking.via/meta-csp-report-uri-2">
 
 <!-- 
 %Reading View
@@ -125,10 +125,10 @@ Use a network sniffer to detect it.
 <!-- 
 %Links & Maps
 -->
-<a ping="http://leaking.via/a-ping" href="#">You have to click me</a>
+<a ping="https://leaking.via/a-ping" href="#">You have to click me</a>
 <img src="data:;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw" width="150" height="150" usemap="#map">
 <map name="map">
-  <area ping="http://leaking.via/area-ping" shape="rect" coords="0,0,150,150" href="#">
+  <area ping="https://leaking.via/area-ping" shape="rect" coords="0,0,150,150" href="#">
 </map> 
 <!-- 
 The ping attribute allows to send a HTTP request to an external IP or domain, 
@@ -152,7 +152,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
 <img src="https://leaking.via/img-src">
 <img dynsrc="https://leaking.via/img-dynsrc">
 <img lowsrc="https://leaking.via/img-lowsrc">
-<img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='%68ttp:%2f/leaking.via/svg-via-data'></image></svg>">
+<img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='%68ttps:%2f/leaking.via/svg-via-data'></image></svg>">
 
 <image src="https://leaking.via/image-src">
 <image href="https://leaking.via/image-href">
@@ -441,6 +441,12 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
 -->
 <xml src="https://leaking.via/xml-src" id="xml"></xml>
 <div datasrc="#xml" datafld="$text" dataformatas="html"></div>
+<script language="xml">
+    <!DOCTYPE html SYSTEM "https://leaking.via/script-doctype">
+</script>
+<xml>
+    <!DOCTYPE html SYSTEM "https://leaking.via/xml-doctype">
+</xml>
 
 <!-- 
 %VML


### PR DESCRIPTION
IE's XML data islands can be placed in HTML document directly: https://msdn.microsoft.com/en-us/library/ms766512(v=vs.85).aspx
I noticed a request is sent via the doctype declaration. Of course it works on only old docmode.