### PR TITLE
Add profile attribute to the <head> tag.

### DIFF
--- a/leak.html
+++ b/leak.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html SYSTEM "https://leaking.via/doctype">
 <html xmlns="http://www.w3.org/1999/xhtml" manifest="https://leaking.via/html-manifest">
-<head>
+<head profile="https://leaking.via/head-profile">
 
 <!--
 %Base (check manually)


### PR DESCRIPTION
Deprecated attribute that was used for indicating namespaces (just like XML's "xmlns" attributes).
- https://www.w3.org/2002/12/namespace
- https://www.w3schools.com/tags/tag_head.asp