### PR TITLE
Added <link rel=preload> variants

### DIFF
--- a/leak.html
+++ b/leak.html
@@ -71,11 +71,13 @@
 <link rel="prerender" href="https://leaking.via/link-prerender" />
 <link rel="modulepreload" href="https://leaking.via/link-modulepreload" />
 
+<link rel="preload" as="fetch" href="https://leaking.via/link-preload-as-fetch" />
 <link rel="preload" as="font" href="https://leaking.via/link-preload-as-font" />
 <link rel="preload" as="image" href="https://leaking.via/link-preload-as-image" />
 <link rel="preload" as="image" imagesrcset=",,,,,https://leaking.via/link-preload-imagesrcset" />
 <link rel="preload" as="style" href="https://leaking.via/link-preload-as-style" />
 <link rel="preload" as="script" href="https://leaking.via/link-preload-as-script" />
+<link rel="preload" as="track" href="https://leaking.via/link-preload-as-track" />
 
 <link rel="search" href="https://leaking.via/link-search" />
 <!--


### PR DESCRIPTION
`as=fetch` and `as=track` are supported by modern browsers.